### PR TITLE
chore: remove default export from browser.d.ts

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,2 +1,1 @@
 export * from './dist/browser';
-export { default } from './dist/browser';


### PR DESCRIPTION
Fix  Module '"./dist/browser"' has no exported member 'default'. error